### PR TITLE
Rename LOWPOWERTIMER to LPTICKER

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 #include "mbed.h"
 
-#if !defined(MBED_CPU_STATS_ENABLED) || !defined(DEVICE_LOWPOWERTIMER) || !defined(DEVICE_SLEEP)
+#if !defined(MBED_CPU_STATS_ENABLED) || !defined(DEVICE_LPTICKER) || !defined(DEVICE_SLEEP)
 #error [NOT_SUPPORTED] test not supported
 #endif
 


### PR DESCRIPTION
This flag changed name in Mbed OS.

@ARMmbed/mbed-os-maintainers This is needed for https://github.com/ARMmbed/mbed-os/pull/7009 can you please merge and run test on https://github.com/ARMmbed/mbed-os/pull/7009