### PR TITLE
Make compatible with Minimal-printf

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -44,10 +44,10 @@ void print_stats()
     mbed_stats_cpu_t stats;
     mbed_stats_cpu_get(&stats);
 
-    printf("%-20lld", stats.uptime);
-    printf("%-20lld", stats.idle_time);
-    printf("%-20lld", stats.sleep_time);
-    printf("%-20lld\n", stats.deep_sleep_time);
+    printf("Uptime: %lld", stats.uptime);
+    printf(" Idle Time: %lld", stats.idle_time);
+    printf(" Sleep time: %lld", stats.sleep_time);
+    printf(" DeepSleep time: %lld\n", stats.deep_sleep_time);
 }
 
 int main()
@@ -58,7 +58,6 @@ int main()
     int id;
 
     id = stats_queue->call_every(SAMPLE_TIME, print_stats);
-    printf("%-20s%-20s%-20s%-20s\n", "Uptime", "Idle Time", "Sleep time", "DeepSleep time");
 
     thread = new Thread(osPriorityNormal, MAX_THREAD_STACK);
     thread->start(busy_thread);

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,8 +3,12 @@
 Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
 
 To run the test, use following command after you build the example:
+```bash
+$ mbedhtrun -d <MOUNT_POINT> -p <SERIAL_PORT> -m <TARGET> -f ./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-cpu-stats.bin --compare-log tests/cpu-stats.log
 ```
-mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\cpu-stats.bin --compare-log tests\cpu-stats.log
+For example:
+```bash
+$ mbedhtrun -d /media/user01/DAPLINK -p /dev/ttyACM0 -m K64F -f ./BUILD/K64F/GCC_ARM/mbed-os-example-cpu-stats.bin --compare-log tests/cpu-stats.log
 ```
 
 

--- a/tests/cpu-stats.log
+++ b/tests/cpu-stats.log
@@ -1,19 +1,18 @@
-Uptime\s+Idle Time\s+Sleep time\s+DeepSleep time
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
-\d+\s+\d+\s+\d+\s+\d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+
+Uptime: \d+ Idle Time: \d+ Sleep time: \d+ DeepSleep time: \d+


### PR DESCRIPTION
Remove flags and width format sub-specifiers on `printf()` calls as
Minimal-printf does not support them. This commit ensures that the
output when built with Minimal-printf is legible and similar to the
output when using the standard library.