### PR TITLE
Update for mbed-os-6.11.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#9738b27c7df897c29e9769911d6794ba3e5b3f19
+https://github.com/ARMmbed/mbed-os/#14e5d307bb6cdccb554b591ab2602d8d47e0b2d0


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.11.0 release of mbed-os. 